### PR TITLE
Add file and directory that regression test generates, to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
 *.so
+regression.*
+/results/


### PR DESCRIPTION
Add regression.\* and /results/ into .gitignore file, in order to exclude
files and directories that regression test generates, from git repository.
